### PR TITLE
do not log or kill tunnel when there is no tunnel

### DIFF
--- a/lib/tunnel-launcher.js
+++ b/lib/tunnel-launcher.js
@@ -171,11 +171,11 @@ function downloadAndRun(options, callback)
 }
 
 function exitHandler(options, err) {
-    if (err) {
+    if (activeTunnel && err) {
     	logger(err.stack);
     }
 
-    if (options.cleanup) {
+    if (activeTunnel && options.cleanup) {
     	logger("Shutting down tunnel");
     	killTunnel();
     }


### PR DESCRIPTION
The log message fired even without a tunnel started and the err object was defined when a test failed
