### PR TITLE
chore: adds EditorConfig to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I've expanded the https://raw.githubusercontent.com/testingbot/wdio-testingbot-service/master/.editorconfig for Markdown files to allow linebreaks via spaces.
