### PR TITLE
fix: log error messages, even if verbose mode is false

### DIFF
--- a/lib/tunnel-launcher.js
+++ b/lib/tunnel-launcher.js
@@ -107,7 +107,7 @@ function run(options, callback)
 	    if (options.verbose && data !== "") {
 	      logger(data);
 	    }
-        if (data.indexOf('is available for download') > -1) {
+        if (data.indexOf('is available for download') > -1 || data.indexOf('An error ocurred') > -1) {
         	logger(data);
         } else if (data.indexOf('error code : 401') > -1) {
         	logger("Invalid credentials, please specify the correct KEY and SECRET retrieved from https://testingbot.com");


### PR DESCRIPTION
This will print all messages that are logged via the error stream: https://github.com/testingbot/Testingbot-Tunnel/blob/master/src/main/java/com/testingbot/tunnel/App.java#L281
