### PR TITLE
fix: do not modify process.exit result when no tunnel is running

### DIFF
--- a/lib/tunnel-launcher.js
+++ b/lib/tunnel-launcher.js
@@ -169,11 +169,15 @@ function downloadAndRun (options, callback) {
 }
 
 function exitHandler (options, err) {
-    if (activeTunnel && err) {
+    if (!activeTunnel) {
+        return
+    }
+
+    if (err) {
         logger(err.stack)
     }
 
-    if (activeTunnel && options.cleanup) {
+    if (options.cleanup) {
         logger('Shutting down tunnel')
         killTunnel()
     }


### PR DESCRIPTION
Even when no tunnel was active the process.exit result was intercepted/modified.

See this example and compare the exit code (`echo $?`). Expected was 33, but got 0.

``` js
const testingbotTunnel = require('testingbot-tunnel-launcher');
setTimeout(() => undefined, 2000); // give the user some time to kill the process via CTRL+C
process.on('SIGINT', () => process.exit(33));
```
